### PR TITLE
Added Camera Lean

### DIFF
--- a/Assets/scripts/FollowPlayerScript.cs
+++ b/Assets/scripts/FollowPlayerScript.cs
@@ -5,8 +5,8 @@ using System.Collections;
 public class FollowPlayerScript : MonoBehaviour
 {
 
-		public GameObject car;
-		private Transform target;
+		//public GameObject car;
+		public Transform target;
 		// The distance in the x-z plane to the target
 		public float distance = 5.0f;
 		// the height we want the camera to be above the target
@@ -14,16 +14,26 @@ public class FollowPlayerScript : MonoBehaviour
 
 		public float heightDamping = 2.0f;
 		public float rotationDamping = 3.0f;
+		public float leanDamping = 2.0f;
 
 		// To adjust camera angle, in order to see ahead while driving.
 		public float cameraTilt = 1.5f;
 		public float minDistance = 3.0f;
 
-		public bool zoom = true;
+	    // zoom camera if near plane corner collide with geometry before reaching target
+		public bool camZoom = false;
+
+	    // lean camera toward zenth if sphere collides with geometry
+		public bool camLean = true;
+		public float camCollideRadius = 2.0f;
+
+	    // current distance on the x-z plane of the camera from the target
+		private float currentDistance = 0f;
 	
 		// Use this for initialization
 		void Start () {
-			target = car.transform;
+			//target = car.transform;	
+			currentDistance = distance;
 		}
 	
 		// Update is called once per frame
@@ -42,36 +52,63 @@ public class FollowPlayerScript : MonoBehaviour
 		
 				float currentRotationAngle = transform.eulerAngles.y;
 				float currentHeight = transform.position.y;
-		
-				// Damp the rotation around the y-axis
-				currentRotationAngle = Mathf.LerpAngle (currentRotationAngle, wantedRotationAngle, rotationDamping * Time.deltaTime);
-		
-				// Damp the height
-				currentHeight = Mathf.Lerp (currentHeight, wantedHeight, heightDamping * Time.deltaTime);
-		
-				// Convert the angle into a rotation
-				Quaternion currentRotation = Quaternion.Euler (0f, currentRotationAngle, 0f);
+
+		        if( camLean ) {
+		        	
+			        // calculate the length of the vector from the camera to the target
+					float wantedCamDistanceSquared = (wantedHeight-cameraTilt);
+					wantedCamDistanceSquared *= wantedCamDistanceSquared;
+					wantedCamDistanceSquared = wantedCamDistanceSquared + distance*distance;
+
+					if( Physics.CheckSphere( transform.position, camCollideRadius) )
+					{
+						// move toward zero distance on x-y from target
+						currentDistance = Mathf.Lerp(currentDistance, 0, leanDamping * Time.deltaTime);
+
+					}
+					else
+					{
+						// move toward user defined distance on x-y from target
+						currentDistance = Mathf.Lerp(currentDistance, distance, leanDamping * Time.deltaTime);
+					}
+
+					wantedHeight = Mathf.Sqrt(wantedCamDistanceSquared - currentDistance*currentDistance);     
+				}
 
 				// Set the position of the camera on the x-z plane to:
 				// distance meters behind the target
-				gameObject.transform.position = target.position;
-				gameObject.transform.position -= currentRotation * Vector3.forward * distance;
+				transform.position = target.position;
+
+                if( currentDistance > 0 )
+                {
+					// Damp the rotation around the y-axis
+					currentRotationAngle = Mathf.LerpAngle (currentRotationAngle, wantedRotationAngle, rotationDamping * Time.deltaTime);
+			
+					// Convert the angle into a rotation
+					Quaternion currentRotation = Quaternion.Euler (0f, currentRotationAngle, 0f);
+
+	                // rotate vector from target by angle
+					transform.position -= currentRotation * Vector3.forward * currentDistance;
+				}
+
+				// Damp the height
+				currentHeight = Mathf.Lerp (currentHeight, wantedHeight, heightDamping * Time.deltaTime);
 		
 				// Set the height of the camera
-				transform.position = new Vector3 (transform.position.x, currentHeight, transform.position.z);
+				transform.position = new Vector3 (transform.position.x, currentHeight, transform.position.z);				
 
 				// Always look a bit (value of cameraTilt) over the target.
-				Vector3 lookAtPt = new Vector3(target.transform.position.x, target.transform.position.y + cameraTilt, target.transform.position.z);
+				Vector3 lookAtPt = new Vector3(target.position.x, target.position.y + cameraTilt, target.position.z);
 				transform.LookAt(lookAtPt);
 
-		        if( zoom ) {
+				if( camZoom ) {
 					Ray[] frustumRays = new Ray[4];
 
 					frustumRays[0] = transform.camera.ScreenPointToRay(new Vector3(0,0,0));
 					frustumRays[1] = transform.camera.ScreenPointToRay(new Vector3(transform.camera.pixelWidth,0,0));
 					frustumRays[2] = transform.camera.ScreenPointToRay(new Vector3(0,transform.camera.pixelHeight,0));
 					frustumRays[3] = transform.camera.ScreenPointToRay(new Vector3(transform.camera.pixelWidth,transform.camera.pixelHeight,0));
-
+		
 					transform.position = HandleCollisionZoom(transform.position, lookAtPt, minDistance, ref frustumRays);
 				}
 		}


### PR DESCRIPTION
Added camera lean in response to level geometry that would clip through the camera frustum
This is togglable on the options the FollowPlayerScript.cs attached to the camera. This update pertains to Issue #36.

Camera lean works by using a sphere around the camera. If a collider that is not part of a cart collides with this sphere, the camera leans downward to look directly at the cart. If nothing is colliding with the sphere, it leans a fixed position above and behind the cart.

Also, I added AddComponentMenu command to match a similar line in SmoothFollow.js

Notes:
-SmoothFollow.js is the current selected script for the buggy camera. It is set to be removed.
-You need to manually set the buggy to use FollowPlayerScript.cs
-The cart colliders (or even the entire buggy GameObject) should be placed in the "Ignore Raycast" layer so that they don't set off the camera themselves.
-Camera Zoom may be removed.
