### PR TITLE
Fix camera indicator appearing on main cam

### DIFF
--- a/Assets/scenes/level_01_local_multi.unity
+++ b/Assets/scenes/level_01_local_multi.unity
@@ -722,7 +722,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -1031,6 +1031,10 @@ Prefab:
     - target: {fileID: 100004, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
@@ -1362,6 +1366,10 @@ Prefab:
       propertyPath: m_LocalPosition.y
       value: -.368591309
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
@@ -1444,7 +1452,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -3895,7 +3903,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -3976,7 +3984,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -7040,6 +7048,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
   m_RootGameObject: {fileID: 1787391472}
@@ -7410,7 +7422,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -8654,7 +8666,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -9050,6 +9062,10 @@ Prefab:
     - target: {fileID: 100004, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
@@ -9561,7 +9577,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -9981,7 +9997,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -10646,6 +10662,10 @@ Prefab:
       propertyPath: m_NormalizedViewPortRect.height
       value: .5
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
   m_RootGameObject: {fileID: 932500971}
@@ -10698,6 +10718,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
   m_RootGameObject: {fileID: 1911609846}
@@ -10745,6 +10769,10 @@ Prefab:
     - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
       propertyPath: m_NormalizedViewPortRect.height
       value: .5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
@@ -12382,6 +12410,10 @@ Prefab:
       propertyPath: m_NormalizedViewPortRect.height
       value: .5
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
   m_RootGameObject: {fileID: 1232397803}
@@ -12857,7 +12889,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -13301,6 +13333,10 @@ Prefab:
       propertyPath: isSingleView
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
@@ -13420,6 +13456,10 @@ Prefab:
     - target: {fileID: 100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
@@ -14051,7 +14091,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -14564,7 +14604,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -15982,7 +16022,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -16871,6 +16911,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
   m_RootGameObject: {fileID: 151448198}
@@ -16922,6 +16966,10 @@ Prefab:
     - target: {fileID: 100004, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
@@ -16978,6 +17026,10 @@ Prefab:
     - target: {fileID: 100004, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 7a33917f60adcd04c98ca10599517255, type: 2}
@@ -17464,7 +17516,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -17654,7 +17706,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -19541,6 +19593,10 @@ Prefab:
     - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
       propertyPath: m_NormalizedViewPortRect.height
       value: .5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a1dee1f88cf0ad54394e5b11a2e578db, type: 2}

--- a/Assets/scenes/level_full.unity
+++ b/Assets/scenes/level_full.unity
@@ -3373,7 +3373,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -3519,7 +3519,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0
@@ -6741,6 +6741,14 @@ Prefab:
       propertyPath: m_swingScript
       value: 
       objectReference: {fileID: 489195832}
+    - target: {fileID: 2000002, guid: fcef4560af670864ba96f4861e9a1e9f, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000004, guid: fcef4560af670864ba96f4861e9a1e9f, type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 4294966783
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 11400026, guid: fcef4560af670864ba96f4861e9a1e9f, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: fcef4560af670864ba96f4861e9a1e9f, type: 2}
@@ -7480,7 +7488,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967039
+    m_Bits: 4294966783
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_HDR: 0

--- a/Assets/scripts/FollowPositionScript.cs
+++ b/Assets/scripts/FollowPositionScript.cs
@@ -15,8 +15,11 @@ public class FollowPositionScript : MonoBehaviour {
 
 	public float rotationDamping = 3.0f;
 
+	Vector3 startPosition;
+
 	// Use this for initialization
 	void Start () {
+		startPosition = gameObject.transform.position;
 	}
 	
 	// Update is called once per frame
@@ -38,16 +41,19 @@ public class FollowPositionScript : MonoBehaviour {
 			position.x = target.position.x;
 			position.z = target.position.z;
 			rotationEulerAngles.y = Mathf.LerpAngle(rotationEulerAngles.y, target.eulerAngles.y, rotationDamping * Time.deltaTime);
+			position.y = startPosition.y;
 		}
 		else if (followPlane == PlaneType.XY) {
 			position.x = target.position.x;
 			position.z = target.position.y;
 			rotationEulerAngles.z = Mathf.LerpAngle(rotationEulerAngles.z, target.eulerAngles.z, rotationDamping * Time.deltaTime);
+			position.z = startPosition.z;
 		}
 		else if (followPlane == PlaneType.YZ) {
 			position.x = target.position.y;
 			position.z = target.position.z;
 			rotationEulerAngles.x = Mathf.LerpAngle(rotationEulerAngles.x, target.eulerAngles.x, rotationDamping * Time.deltaTime);
+			position.x = startPosition.x;
 		}
 		
 		rotation.eulerAngles = rotationEulerAngles;


### PR DESCRIPTION
Issue #144 
The indicator seems to appear when the map pulls up. Currently happens when the cart goes off screen, but still shouldn't be visible.
Also made sure indicator remains in the same vertical position.
