### PR TITLE
Added MiniMap Script

### DIFF
--- a/Assets/scripts/MiniMap.cs
+++ b/Assets/scripts/MiniMap.cs
@@ -7,14 +7,14 @@ public class MiniMap : MonoBehaviour {
 	public Texture2D playerIcon;
 	public Texture2D playerDirectionIcon;
 	public Texture2D ballIcon;
-	public float iconScale = 0.2f;
+	public float iconScale = 0.3f;
 
-	public Color playerColor;
+	public Color playerColor = new Color(1,0,0,1);
 	
 	public Transform player;
 	public Transform flag;
 	public Transform ball;
-	public Mesh level;
+	public GameObject level;
 	public Camera mapCamera;
 
 	private Rect playerPos;
@@ -54,8 +54,8 @@ public class MiniMap : MonoBehaviour {
 
 	// Obtains the screenspace bounds of the minimap camera
 	void UpdateCameraBounds() {
-		camMin = mapCamera.WorldToScreenPoint( level.bounds.min );
-		camMax = mapCamera.WorldToScreenPoint( level.bounds.max );
+		camMin = mapCamera.WorldToScreenPoint( level.collider.bounds.min );
+		camMax = mapCamera.WorldToScreenPoint( level.collider.bounds.max );
 	}
 
 	void UpdateIconSize() {
@@ -83,9 +83,11 @@ public class MiniMap : MonoBehaviour {
 		//ballPos.center   = new Vector2( camBall.x, Screen.height - camBall.y );
 		//flagPos.center   = new Vector2( camFlag.x, Screen.height - camFlag.y - flagPos.height * 0.5f );
 
-		playerPos.center = NormalizedPosition( player.position, level.bounds.min, level.bounds.max, camMin, camMax );
-		ballPos.center = NormalizedPosition( ball.position, level.bounds.min, level.bounds.max, camMin, camMax );
-		flagPos.center = NormalizedPosition( flag.position, level.bounds.min, level.bounds.max, camMin, camMax );
+		playerPos.center = NormalizedPosition( player.position, level.collider.bounds.min, level.collider.bounds.max, camMin, camMax );
+		ballPos.center = NormalizedPosition( ball.position, level.collider.bounds.min, level.collider.bounds.max, camMin, camMax );
+		flagPos.center = NormalizedPosition( flag.position, level.collider.bounds.min, level.collider.bounds.max, camMin, camMax );
+
+		flagPos.center = new Vector2( flagPos.center.x, flagPos.center.y - flagPos.height * 0.5f);
 
 	}
 


### PR DESCRIPTION
Same script from closed pull request #172. It renders icons on the overview map discussed in Issue #85. This script is currently not hooked up to the level scenes. It should be done programmatically, once the golfball, player and flag GameObjects have known names. Here are the inputs:

// Icons discussed in Issues #111, Issues #119, and Issue #110. Tested with the 512x512 TGA files.
Texture2D flagIcon;
Texture2D playerIcon;
Texture2D playerDirectionIcon;
Texture2D ballIcon;

float iconScale            // relative size of the icons on the MiniMap
Color playerColor       // main chosen color of player. Default color is red.
Transform player;        // GameObject of the client's cart
Transform flag;            // GameObject of the pin/hole.
Transform ball;            // GameObject of the client's ball
GameObject level;       // GameObject of the current level
Camera mapCamera;  // MiniMap camera
