### PR TITLE
CarAudio uses volume/mute from SoundManager

### DIFF
--- a/Assets/scripts/cart/CarUserControl.cs
+++ b/Assets/scripts/cart/CarUserControl.cs
@@ -21,7 +21,7 @@ public class CarUserControl : MonoBehaviour
 		//if(CrossPlatformInput.GetAction3());	//Probably not right
 #else
 		if(Input.GetKeyDown(KeyCode.Q))
-			SoundManager.Get().playSfx3d(gameObject, "Car Horn 1", 5, 500, 1);
+			SoundManager.Get().playSfx3d(gameObject, "horn1", 5, 500, 1);
 #endif
 	}
 

--- a/Assets/scripts/network/controlClient.cs
+++ b/Assets/scripts/network/controlClient.cs
@@ -155,7 +155,7 @@ public class controlClient : MonoBehaviour {
 		// find the player
 		foreach (PlayerInfo p in nvs.players) {
 			if (p.player==player) {
-				SoundManager.Get().playSfx3d(p.cartGameObject, "Car Horn 1", 5, 500, 1);
+				SoundManager.Get().playSfx3d(p.cartGameObject, "horn1", 5, 500, 1);
 			}
 		}
 	}

--- a/Assets/scripts/network/controlServer.cs
+++ b/Assets/scripts/network/controlServer.cs
@@ -160,7 +160,7 @@ public class controlServer : MonoBehaviour {
 		// find the player
 		foreach (PlayerInfo p in nvs.players) {
 			if (p.player==player) {
-				SoundManager.Get().playSfx3d(p.cartGameObject, "Car Horn 1", 5, 500, 1);
+				SoundManager.Get().playSfx3d(p.cartGameObject, "horn1", 5, 500, 1);
 			}
 		}
 	}


### PR DESCRIPTION
Fixed horn ingame -- The horn sound clip was renamed at some point
Fixed offline game sounds -- attached sound sources to the audio listener's object so they can be heard anywhere, effectively making them 2D (there is no Unity setting that makes them 2D in script).
AudioSources are now stopped instead of destroyed. #253 
CarAudio now uses the sfxVolume, muteSfx, and muteAllSound from SoundManager. #194 
