### PR TITLE
No more random edits on project load

### DIFF
--- a/Assets/scripts/gui/attachments/UIAnchorToScreen.cs
+++ b/Assets/scripts/gui/attachments/UIAnchorToScreen.cs
@@ -3,7 +3,6 @@ using System.Collections;
 
 //probably only works as intended with orthogonal camera
 
-[ExecuteInEditMode]
 public class UIAnchorToScreen : MonoBehaviour 
 {
 	private int screenWidth = 0;
@@ -23,6 +22,11 @@ public class UIAnchorToScreen : MonoBehaviour
 #if UNITY_EDITOR
 	public bool setPercentsFromCurrentTransforms = false;
 #endif
+	
+	void Start () 
+	{
+		onScreenResize();
+	}
 
 	void Update () 
 	{


### PR DESCRIPTION
Small patch to stop Unity from thinking that you've made an edit when you load up the editor.

This makes the start screen only change size when the game starts and not whilst in the editor (I have a weird resolution that changes the size and makes Unity think I've made an edit, which then gets reversed any time anyone else edits main.unity)
