### PR TITLE
Remove the custom servers since they don't exist anymore.

### DIFF
--- a/Assets/scripts/network/networkManager.cs
+++ b/Assets/scripts/network/networkManager.cs
@@ -35,14 +35,6 @@ public class networkManager : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
-		// change to custom master server
-		MasterServer.ipAddress = "37.157.247.37";
-		MasterServer.port = 23466;
-
-		// NAT punchthrough (finally)
-		Network.natFacilitatorIP = "37.157.247.37";
-		Network.natFacilitatorPort = 50005;
-
 		nvs = GameObject.FindWithTag("NetObj").GetComponent("networkVariables") as networkVariables;
 		// get server version
 		serverVersion = nvs.serverVersion;


### PR DESCRIPTION
This will default back to using one of Unity's servers instead.
If someone else feels they want to host these then go for it and submit the relevant patch to bring them back. Both the MasterServer and the Facilitator are readily available from Unity's website and don't require much overhead - they're used for matchmaking rather than simulating the game, so barely any CPU or RAM usage, plus matchmaking isn't exactly network intensive either...

Also sorry if this rudely awakens everyone who at some point had something to do with this project, but I thought I'd commit this before I get complained at by The Big Cheese (Cheeseness) :D